### PR TITLE
Using private grid._depth for negating depth (#75)

### DIFF
--- a/src/virtualship/expedition/input_data.py
+++ b/src/virtualship/expedition/input_data.py
@@ -97,7 +97,9 @@ class InputData:
 
         # make depth negative
         for g in fieldset.gridset.grids:
-            g.depth = -g.depth
+            g._depth = (
+                -g._depth
+            )  # TODO maybe add a grid.negate_depth() method in Parcels?
 
         # add bathymetry data
         bathymetry_file = directory.joinpath("bathymetry.nc")
@@ -137,7 +139,7 @@ class InputData:
 
         # make depth negative
         for g in fieldset.gridset.grids:
-            g.depth = -g.depth
+            g._depth = -g._depth
 
         # read in data already
         fieldset.computeTimeChunk(0, 1)
@@ -169,7 +171,7 @@ class InputData:
         # make depth negative
         for g in fieldset.gridset.grids:
             if max(g.depth) > 0:
-                g.depth = -g.depth
+                g._depth = -g._depth
 
         # read in data already
         fieldset.computeTimeChunk(0, 1)


### PR DESCRIPTION
* Using private grid._depth for negating depth

As Parcels v3.1.0 has moved from `grid.depth` to `grid._depth`, the code for VirtualShip is now broken. THis PR fixes that, although a more propoer implementation would be to add a grid.negate_depth() method to Parcels itself?

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

---------